### PR TITLE
UF-113 fix: ResponseBody 수정

### DIFF
--- a/src/main/java/com/example/ufo_fi/global/response/ResponseBody.java
+++ b/src/main/java/com/example/ufo_fi/global/response/ResponseBody.java
@@ -7,28 +7,39 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public class ResponseBody<T> {
-    private final HttpStatus statusCode;
+    private final int statusCode;
     private final String message;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private T data;
+    private T content;
 
-    //예외가 없을 시 사용되는 생성자
-    public ResponseBody(T data) {
-        this.statusCode = HttpStatus.OK;
+    //성공 시 생성자
+    public ResponseBody(T content) {
+        this.statusCode = HttpStatus.OK.value();
         this.message = HttpStatus.OK.getReasonPhrase();
-        this.data = data;
+        this.content = content;
+    }
+
+    //No-Content 생성자
+    public ResponseBody(){
+        this.statusCode = HttpStatus.NO_CONTENT.value();
+        this.message = HttpStatus.NO_CONTENT.getReasonPhrase();
     }
 
     //에러 코드를 반환하는 생성자
     public ResponseBody(ErrorCode errorCode) {
-        this.statusCode = errorCode.getStatus();
+        this.statusCode = errorCode.getStatus().value();
         this.message = errorCode.getMessage();
     }
 
     //성공 시 컨트롤러에서 DTO(data)를 ResponseEntity<ResponseBody>로 변환해 반환한다.
-    public static <T> ResponseBody<T> success(T data) {
-        return new ResponseBody<>(data);
+    public static <T> ResponseBody<T> success(T content) {
+        return new ResponseBody<>(content);
+    }
+
+    //아무 응답값도 없을 시 사용한다.
+    public static ResponseBody<Void> noContent(){
+        return new ResponseBody<>();
     }
 
     //에러 코드를 GlobalExceptionHandler에서 받아 ResponseEntity<ResponseBody>로 변환해 반환한다.


### PR DESCRIPTION
- data -> content
- no-content 추가
- statusCode(HttpStauts)->statusCode(int)

### #️⃣ 연관된 이슈

> close: #21 

### 🔎 작업 내용

- [x] status code 수정

### 📸 스크린샷 (선택)

### 📢 전달사항

- 이제 no-content를 전달할 수 있습니다.

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for responses with HTTP 204 No Content status.

* **Improvements**
  * Response structure updated: the field previously named "data" is now labeled "content" in all responses.
  * Status codes in responses are now represented as integers for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->