### PR TITLE
UF-108 add fcm sendmessage

### DIFF
--- a/src/main/java/com/example/ufo_fi/domain/notification/config/FirebaseConfig.java
+++ b/src/main/java/com/example/ufo_fi/domain/notification/config/FirebaseConfig.java
@@ -7,6 +7,7 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ClassPathResource;
 
 import java.io.IOException;
@@ -14,22 +15,24 @@ import java.io.InputStream;
 
 /**
  * Firebase 설정 클래스
- * 1. 설정 파일 경로가 주어졌을 경우에만 FirebaseApp을 초기화한다.
- * 2. 이미 초기화된 FirebaseApp이 있다면 기존 인스턴스를 반환한다.
- * 3. FirebaseApp이 정상적으로 초기화된 경우에만 FirebaseMessaging Bean을 등록한다.
- * 그렇지 않으면 null을 반환하여 초기화를 회피하도록 한다.
+ * - Firebase와 연동하기 위한 초기화 작업을 수행하며, Firebase 관련 Bean(FirebaseApp, FirebaseMessaging)을 등록함
+ * - test 환경에서는 로딩되지 않도록 @Profile 적용
  */
+@Profile("!test")
 @Configuration
 public class FirebaseConfig {
 
     @Value("${firebase.config-path:}")
     private String firebaseConfigPath;
 
+    /**
+     * FirebaseApp Bean 등록 메서드
+     * 1. FirebaseApp은 서비스를 사용할 수 있게 해주는 객체임
+     * 2. firebaseConfigPath에 정의된 비밀 키 파일을 읽어 FirebaseApp을 초기화
+     * 3. 이미 초기화된 FirebaseApp 인스턴스가 존재하면 해당 인스턴스를 반환
+     */
     @Bean
     public FirebaseApp firebaseApp() {
-        if (firebaseConfigPath == null || firebaseConfigPath.isBlank()) {
-            return null;
-        }
 
         try (InputStream serviceAccount = new ClassPathResource(firebaseConfigPath.trim()).getInputStream()) {
             FirebaseOptions options = FirebaseOptions.builder()
@@ -49,11 +52,13 @@ public class FirebaseConfig {
         }
     }
 
+    /**
+     * FirebaseMessaging Bean 등록 메서드
+     * 1. FCM 서비스를 사용할 수 있게 해주는 FCM 객체
+     * 2. firebaseApp 인스턴스를 받아  firebaseMassaging 인스턴스로 반환
+     */
     @Bean
     public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
-        if (firebaseApp == null) {
-            return null;
-        }
         return FirebaseMessaging.getInstance(firebaseApp);
     }
 }

--- a/src/main/java/com/example/ufo_fi/domain/notification/controller/FcmTokenController.java
+++ b/src/main/java/com/example/ufo_fi/domain/notification/controller/FcmTokenController.java
@@ -1,0 +1,30 @@
+package com.example.ufo_fi.domain.notification.controller;
+
+import com.example.ufo_fi.domain.notification.dto.request.FcmTokenSaveReq;
+import com.example.ufo_fi.domain.notification.dto.response.FcmTokenCommonRes;
+import com.example.ufo_fi.domain.notification.service.FcmTokenService;
+import com.example.ufo_fi.global.response.ResponseBody;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class FcmTokenController {
+
+    private final FcmTokenService fcmTokenService;
+
+    // GetMapping, 해당 사용자의 FCM 토큰을 저장
+    @PostMapping("v1/fcm/token")
+    public ResponseEntity<ResponseBody<FcmTokenCommonRes>> saveToken(
+            // @AuthenticationPrincipal CustomUserDetails customUserDetails
+            @RequestBody FcmTokenSaveReq request) {
+
+        // TODO: 추후 인증 연동 시 @AuthenticationPrincipal 사용하여 userId 추출
+        Long userId = 1L;
+
+        return ResponseEntity.ok(ResponseBody.success(fcmTokenService.save(userId, request.getToken())));
+    }
+}

--- a/src/main/java/com/example/ufo_fi/domain/notification/dto/request/FcmTokenSaveReq.java
+++ b/src/main/java/com/example/ufo_fi/domain/notification/dto/request/FcmTokenSaveReq.java
@@ -1,0 +1,10 @@
+package com.example.ufo_fi.domain.notification.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FcmTokenSaveReq {
+    private String token;
+}

--- a/src/main/java/com/example/ufo_fi/domain/notification/dto/response/FcmTokenCommonRes.java
+++ b/src/main/java/com/example/ufo_fi/domain/notification/dto/response/FcmTokenCommonRes.java
@@ -1,0 +1,4 @@
+package com.example.ufo_fi.domain.notification.dto.response;
+
+public record FcmTokenCommonRes(Long id) {
+}

--- a/src/main/java/com/example/ufo_fi/domain/notification/entity/FcmToken.java
+++ b/src/main/java/com/example/ufo_fi/domain/notification/entity/FcmToken.java
@@ -1,15 +1,7 @@
 package com.example.ufo_fi.domain.notification.entity;
 
 import com.example.ufo_fi.domain.user.entity.User;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,4 +25,11 @@ public class FcmToken {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    public static FcmToken of(String token, User user) {
+        return FcmToken.builder()
+                .fcm(token)
+                .user(user)
+                .build();
+    }
 }

--- a/src/main/java/com/example/ufo_fi/domain/notification/exception/NotificationErrorCode.java
+++ b/src/main/java/com/example/ufo_fi/domain/notification/exception/NotificationErrorCode.java
@@ -13,6 +13,8 @@ public enum NotificationErrorCode implements ErrorCode {
 
     // FCM
     FIREBASE_INITIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Firebase 초기화에 실패했습니다."),
+
+    // message
     MESSAGE_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Firebase 메시지 전송에 실패했습니다."),
 
     ;

--- a/src/main/java/com/example/ufo_fi/domain/notification/repository/FcmTokenRepository.java
+++ b/src/main/java/com/example/ufo_fi/domain/notification/repository/FcmTokenRepository.java
@@ -1,0 +1,7 @@
+package com.example.ufo_fi.domain.notification.repository;
+
+import com.example.ufo_fi.domain.notification.entity.FcmToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+}

--- a/src/main/java/com/example/ufo_fi/domain/notification/service/FcmTokenService.java
+++ b/src/main/java/com/example/ufo_fi/domain/notification/service/FcmTokenService.java
@@ -1,0 +1,34 @@
+package com.example.ufo_fi.domain.notification.service;
+
+import com.example.ufo_fi.domain.notification.dto.response.FcmTokenCommonRes;
+import com.example.ufo_fi.domain.notification.entity.FcmToken;
+import com.example.ufo_fi.domain.notification.repository.FcmTokenRepository;
+import com.example.ufo_fi.domain.user.UserRepository;
+import com.example.ufo_fi.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FcmTokenService {
+
+    private final UserRepository userRepository;
+    private final FcmTokenRepository fcmTokenRepository;
+
+    /**
+     * FCM 토큰을 저장
+     * 1. 사용자 ID로 User를 조회하고, 존재하지 않으면 예외를 발생한다.
+     * 2. 성공 시, 해당 userId를 응답으로 반환한다.
+     */
+    @Transactional
+    public FcmTokenCommonRes save(Long userId, String token) {
+
+        User user = userRepository.getReferenceById(userId);
+
+        FcmToken fcmToken = FcmToken.of(token, user);
+        fcmTokenRepository.save(fcmToken);
+
+        return new FcmTokenCommonRes(userId);
+    }
+}

--- a/src/main/java/com/example/ufo_fi/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/ufo_fi/domain/notification/service/NotificationService.java
@@ -1,0 +1,17 @@
+package com.example.ufo_fi.domain.notification.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final FirebaseMessaging firebaseMessaging;
+
+    // 알림 보내보기, test만 완료, 미완성 메서드
+    public void sendMessage(String targetToken, String title, String body) {
+
+    }
+}

--- a/src/test/java/com/example/ufo_fi/UfoFiApplicationTests.java
+++ b/src/test/java/com/example/ufo_fi/UfoFiApplicationTests.java
@@ -1,11 +1,14 @@
 package com.example.ufo_fi;
 
+import com.example.ufo_fi.config.TestFirebaseConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
 @SpringBootTest
+@Import(TestFirebaseConfig.class)
 class UfoFiApplicationTests {
 
     @Test

--- a/src/test/java/com/example/ufo_fi/config/TestFirebaseConfig.java
+++ b/src/test/java/com/example/ufo_fi/config/TestFirebaseConfig.java
@@ -1,0 +1,19 @@
+package com.example.ufo_fi.config;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Test시 등록되는 firebaseConfig
+ * 1. 가짜 Bean으로 등록
+ */
+@TestConfiguration
+public class TestFirebaseConfig {
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() {
+        return Mockito.mock(FirebaseMessaging.class);
+    }
+}


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #19

### 🔎 작업 내용

- [x] 클라이언트가 보낸 토큰을 저장하는 로직 구현했습니다.
- [x] 빌드 시, test 환경에서 Bean등록이 되지않아 생성자 주입이 실패하여, TestFirebaseConfig 추가했습니다.

### 📸 스크린샷 (선택)

### 📢 전달사항

- sendMessage 메서드는 FCM을 통한 알림 잘 오는지 확인만 했고 추후에 구현될 것 같습니다.

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an endpoint to save Firebase Cloud Messaging (FCM) tokens for users.
  * Added support for managing and storing FCM tokens.
  * Added foundational service for sending notifications (method currently incomplete).

* **Bug Fixes**
  * Improved environment handling so Firebase configuration is excluded from test environments.

* **Tests**
  * Added test configuration to mock Firebase Messaging for isolated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->