### PR TITLE
UF-133 add 스웨거 설정 추가

### DIFF
--- a/src/main/java/com/example/ufo_fi/domain/notification/controller/FcmControllerApiSpec.java
+++ b/src/main/java/com/example/ufo_fi/domain/notification/controller/FcmControllerApiSpec.java
@@ -1,0 +1,21 @@
+package com.example.ufo_fi.domain.notification.controller;
+
+import com.example.ufo_fi.domain.notification.dto.request.FcmTokenSaveReq;
+import com.example.ufo_fi.domain.notification.dto.response.FcmTokenCommonRes;
+import com.example.ufo_fi.global.response.ResponseBody;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Fcm API", description = "FCM 토큰 관련 API")
+public interface FcmControllerApiSpec {
+
+    // TODO: 추후 인증 연동 시 @AuthenticationPrincipal 사용하여 userId 추출
+    @Operation(summary = "fcm 토큰 저장 API", description = "fcm 토큰을 프론트 측에서 받아온다.")
+    @ApiResponse(useReturnTypeSchema = true)
+    @PostMapping("v1/fcm/token")
+    ResponseEntity<ResponseBody<FcmTokenCommonRes>> saveToken(@RequestBody FcmTokenSaveReq request);
+}

--- a/src/main/java/com/example/ufo_fi/domain/notification/controller/FcmTokenController.java
+++ b/src/main/java/com/example/ufo_fi/domain/notification/controller/FcmTokenController.java
@@ -12,17 +12,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-public class FcmTokenController {
+public class FcmTokenController implements FcmControllerApiSpec{
 
     private final FcmTokenService fcmTokenService;
 
-    // GetMapping, 해당 사용자의 FCM 토큰을 저장
-    @PostMapping("v1/fcm/token")
-    public ResponseEntity<ResponseBody<FcmTokenCommonRes>> saveToken(
-            // @AuthenticationPrincipal CustomUserDetails customUserDetails
-            @RequestBody FcmTokenSaveReq request) {
-
-        // TODO: 추후 인증 연동 시 @AuthenticationPrincipal 사용하여 userId 추출
+    @Override
+    public ResponseEntity<ResponseBody<FcmTokenCommonRes>> saveToken(@RequestBody FcmTokenSaveReq request) {
         Long userId = 1L;
 
         return ResponseEntity.ok(ResponseBody.success(fcmTokenService.save(userId, request.getToken())));

--- a/src/main/java/com/example/ufo_fi/domain/signup/controller/SignupController.java
+++ b/src/main/java/com/example/ufo_fi/domain/signup/controller/SignupController.java
@@ -8,39 +8,25 @@ import com.example.ufo_fi.global.response.ResponseBody;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-public class SignupController {
+public class SignupController implements SignupControllerApiSpec{
     private final SignupService signupService;
 
-    /**
-     * 통신사를 받아 요금제를 받아오는 API
-     */
-    @GetMapping("/plans")
-    public ResponseEntity<ResponseBody<PlansReadRes>> readPlans(
-            @RequestParam(value = "carrier") String rawCarrier
+    @Override
+    public ResponseEntity<ResponseBody<PlansReadRes>> readPlans(@RequestParam(value = "carrier") String rawCarrier
     ){
-        return ResponseEntity.ok(
-                ResponseBody.success(
-                        signupService.readPlans(rawCarrier)));
+        return ResponseEntity.ok(ResponseBody.success(signupService.readPlans(rawCarrier)));
     }
 
-    /**
-     * 회원가입 - 요금제 연동을 맡는 API
-     */
-    @PostMapping("/signup")
-    public ResponseEntity<ResponseBody<SignupRes>> signup(
-            @RequestParam Long userId,
-            @RequestBody @Valid SignupReq signupReq
+    @Override
+    public ResponseEntity<ResponseBody<SignupRes>> signup(@RequestParam Long userId,
+                                                          @RequestBody @Valid SignupReq signupReq
     ){
-        return ResponseEntity.ok(
-                ResponseBody.success(
-                        signupService.updateUserAndUserPlan(userId, signupReq)));
+        return ResponseEntity.ok(ResponseBody.success(signupService.updateUserAndUserPlan(userId, signupReq)));
     }
 }

--- a/src/main/java/com/example/ufo_fi/domain/signup/controller/SignupControllerApiSpec.java
+++ b/src/main/java/com/example/ufo_fi/domain/signup/controller/SignupControllerApiSpec.java
@@ -1,0 +1,29 @@
+package com.example.ufo_fi.domain.signup.controller;
+
+import com.example.ufo_fi.domain.signup.dto.request.SignupReq;
+import com.example.ufo_fi.domain.signup.dto.response.PlansReadRes;
+import com.example.ufo_fi.domain.signup.dto.response.SignupRes;
+import com.example.ufo_fi.global.response.ResponseBody;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Signup API", description = "회원가입 API")
+public interface SignupControllerApiSpec {
+
+    @Operation(summary = "요금제 조회 API", description = "요금제 정보를 받아온다.")
+    @ApiResponse(useReturnTypeSchema = true)
+    @PostMapping("/v1/plans")
+    ResponseEntity<ResponseBody<PlansReadRes>> readPlans(@RequestParam(value = "carrier") String rawCarrier);
+
+    // TODO: 추후 인증 연동 시 @AuthenticationPrincipal 사용하여 userId 추출
+    @Operation(summary = "회원가입 API", description = "유저 정보와 요금제 정보를 포함하여 저장한다.")
+    @ApiResponse(useReturnTypeSchema = true)
+    @PostMapping("/v1/signup")
+    ResponseEntity<ResponseBody<SignupRes>> signup(@RequestParam Long userId, @RequestBody @Valid SignupReq signupReq);
+}

--- a/src/main/java/com/example/ufo_fi/domain/signup/dto/request/UserInfoReq.java
+++ b/src/main/java/com/example/ufo_fi/domain/signup/dto/request/UserInfoReq.java
@@ -8,6 +8,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UserInfoReq {
     private String name;
-    @Pattern(regexp = "^01[016789]-?\\d{3,4}-?\\d{4}$", message = "올바른 휴대폰 번호 형식이 아닙니다.")
+    @Pattern(regexp = "^01[016789]-\\d{3,4}-\\d{4}$", message = "올바른 휴대폰 번호 형식이 아닙니다.")
     private String phoneNumber;
 }

--- a/src/main/java/com/example/ufo_fi/domain/signup/dto/request/UserPlanReq.java
+++ b/src/main/java/com/example/ufo_fi/domain/signup/dto/request/UserPlanReq.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 public class UserPlanReq {
     private String planName;
     private Carrier carrier;
-    private MobileDataType mobileDataAmount;
+    private Integer mobileDataAmount;
     private Boolean isUltimatedAmount;
     private Integer sellMobileDataCapacityGB;
     private MobileDataType mobileDataType;

--- a/src/main/java/com/example/ufo_fi/global/response/ResponseBody.java
+++ b/src/main/java/com/example/ufo_fi/global/response/ResponseBody.java
@@ -2,14 +2,19 @@ package com.example.ufo_fi.global.response;
 
 import com.example.ufo_fi.global.exception.ErrorCode;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
 public class ResponseBody<T> {
+    @Schema(description = "HTTP 상태 코드", example = "200")
     private final int statusCode;
+
+    @Schema(description = "응답 메시지", example = "OK")
     private final String message;
 
+    @Schema(description = "응답 데이터 (성공 시에만 존재)")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private T content;
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #37 

### 🔎 작업 내용

- [x] swagger 추가

### 📸 스크린샷 (선택)

### 📢 전달사항

- signup 패키지 보고 스웨거 추가 따라할 것.
- ApiSpec이라는 인터페이스를 구현하는 방식

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new API endpoints for saving FCM tokens and user signup, with enhanced OpenAPI documentation.
  * Introduced plan retrieval and signup endpoints for improved user onboarding.

* **Improvements**
  * Enforced stricter phone number validation format requiring hyphens.
  * Changed mobile data amount field to accept integer values for better flexibility.
  * Enhanced API documentation with detailed schema descriptions for response fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->