### PR TITLE
UF-116 마이페이지 유저 기본 정보 API 추가

### DIFF
--- a/src/main/java/com/example/ufo_fi/domain/mypage/controller/MyPageUserInfoController.java
+++ b/src/main/java/com/example/ufo_fi/domain/mypage/controller/MyPageUserInfoController.java
@@ -12,12 +12,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 public class MyPageUserInfoController implements MyPageUserInfoApiSpec {
-    private final UserService UserService;
+    private final UserService userService;
 
     @Override
     public ResponseEntity<ResponseBody<UserInfoReadRes>> readMyPageUserInfo(@RequestParam Long userId) {
         return ResponseEntity.ok(
                 ResponseBody.success(
-                        UserService.readUser(userId)));
+                        userService.readUser(userId)));
     }
 }

--- a/src/main/java/com/example/ufo_fi/domain/mypage/controller/MyPageUserInfoController.java
+++ b/src/main/java/com/example/ufo_fi/domain/mypage/controller/MyPageUserInfoController.java
@@ -1,0 +1,23 @@
+package com.example.ufo_fi.domain.mypage.controller;
+
+import com.example.ufo_fi.domain.mypage.controller.api.MyPageUserInfoApiSpec;
+import com.example.ufo_fi.domain.user.dto.response.UserInfoReadRes;
+import com.example.ufo_fi.domain.user.service.UserService;
+import com.example.ufo_fi.global.response.ResponseBody;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MyPageUserInfoController implements MyPageUserInfoApiSpec {
+    private final UserService UserService;
+
+    @Override
+    public ResponseEntity<ResponseBody<UserInfoReadRes>> readMyPageUserInfo(@RequestParam Long userId) {
+        return ResponseEntity.ok(
+                ResponseBody.success(
+                        UserService.readUser(userId)));
+    }
+}

--- a/src/main/java/com/example/ufo_fi/domain/mypage/controller/api/MyPageUserInfoApiSpec.java
+++ b/src/main/java/com/example/ufo_fi/domain/mypage/controller/api/MyPageUserInfoApiSpec.java
@@ -1,0 +1,19 @@
+package com.example.ufo_fi.domain.mypage.controller.api;
+
+import com.example.ufo_fi.domain.user.dto.response.UserInfoReadRes;
+import com.example.ufo_fi.global.response.ResponseBody;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Mypage/UserInfo API", description = "마이페이지 유저 정보 API")
+public interface MyPageUserInfoApiSpec {
+
+    @Operation(summary = "나의 프로필 조회 API", description = "유저 기본 정보를 받아온다.")
+    @ApiResponse(useReturnTypeSchema = true)
+    @GetMapping("/v1/mypage")
+    ResponseEntity<ResponseBody<UserInfoReadRes>> readMyPageUserInfo(@RequestParam Long userId);
+}

--- a/src/main/java/com/example/ufo_fi/domain/notification/service/FcmTokenService.java
+++ b/src/main/java/com/example/ufo_fi/domain/notification/service/FcmTokenService.java
@@ -3,7 +3,7 @@ package com.example.ufo_fi.domain.notification.service;
 import com.example.ufo_fi.domain.notification.dto.response.FcmTokenCommonRes;
 import com.example.ufo_fi.domain.notification.entity.FcmToken;
 import com.example.ufo_fi.domain.notification.repository.FcmTokenRepository;
-import com.example.ufo_fi.domain.user.UserRepository;
+import com.example.ufo_fi.domain.user.repository.UserRepository;
 import com.example.ufo_fi.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/example/ufo_fi/domain/signup/service/SignupService.java
+++ b/src/main/java/com/example/ufo_fi/domain/signup/service/SignupService.java
@@ -10,7 +10,7 @@ import com.example.ufo_fi.domain.signup.dto.request.SignupReq;
 import com.example.ufo_fi.domain.signup.dto.response.PlansReadRes;
 import com.example.ufo_fi.domain.signup.dto.response.SignupRes;
 import com.example.ufo_fi.domain.signup.exception.SignupErrorCode;
-import com.example.ufo_fi.domain.user.UserRepository;
+import com.example.ufo_fi.domain.user.repository.UserRepository;
 import com.example.ufo_fi.domain.user.entity.Role;
 import com.example.ufo_fi.domain.user.entity.User;
 import com.example.ufo_fi.domain.userplan.entity.UserPlan;

--- a/src/main/java/com/example/ufo_fi/domain/tradepost/service/TradePostService.java
+++ b/src/main/java/com/example/ufo_fi/domain/tradepost/service/TradePostService.java
@@ -8,7 +8,7 @@ import com.example.ufo_fi.domain.tradepost.entity.TradePost;
 import com.example.ufo_fi.domain.tradepost.entity.TradePostStatus;
 import com.example.ufo_fi.domain.tradepost.exception.TradePostErrorCode;
 import com.example.ufo_fi.domain.tradepost.repository.TradePostRepository;
-import com.example.ufo_fi.domain.user.UserRepository;
+import com.example.ufo_fi.domain.user.repository.UserRepository;
 import com.example.ufo_fi.domain.user.entity.User;
 import com.example.ufo_fi.domain.useraccount.UserAccountRepository;
 import com.example.ufo_fi.global.exception.GlobalException;

--- a/src/main/java/com/example/ufo_fi/domain/user/UserRepository.java
+++ b/src/main/java/com/example/ufo_fi/domain/user/UserRepository.java
@@ -1,8 +1,0 @@
-package com.example.ufo_fi.domain.user;
-
-import com.example.ufo_fi.domain.user.entity.User;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface UserRepository extends JpaRepository<User, Long> {
-
-}

--- a/src/main/java/com/example/ufo_fi/domain/user/dto/response/UserInfoReadRes.java
+++ b/src/main/java/com/example/ufo_fi/domain/user/dto/response/UserInfoReadRes.java
@@ -1,0 +1,30 @@
+package com.example.ufo_fi.domain.user.dto.response;
+
+import com.example.ufo_fi.domain.user.entity.User;
+import com.example.ufo_fi.domain.userplan.entity.UserPlan;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInfoReadRes {
+    private String nickname;
+    private String email;
+    private Integer sellMobileDataCapacityGb;
+    private Integer sellableDataAmount;
+    private Integer zetAsset;
+
+    public static UserInfoReadRes of(final User user, final UserPlan userPlan){
+        return UserInfoReadRes.builder()
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .sellMobileDataCapacityGb(userPlan.getSellMobileDataCapacityGb())
+                .sellableDataAmount(userPlan.getSellableDataAmount())
+                .zetAsset(user.getZetAsset())
+                .build();
+    }
+}

--- a/src/main/java/com/example/ufo_fi/domain/user/entity/User.java
+++ b/src/main/java/com/example/ufo_fi/domain/user/entity/User.java
@@ -47,6 +47,9 @@ public class User {
     @Column(name = "phone_number")
     private String phoneNumber;
 
+    @Column(name = "zet_asset")
+    private Integer zetAsset;
+
     @Column(name = "is_active")
     private Boolean isActive;
 

--- a/src/main/java/com/example/ufo_fi/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/example/ufo_fi/domain/user/exception/UserErrorCode.java
@@ -1,0 +1,33 @@
+package com.example.ufo_fi.domain.user.exception;
+
+import com.example.ufo_fi.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+    NO_USER(HttpStatus.NOT_FOUND, "식별되지 않은 사용자입니다."),
+    NO_PHOTO(HttpStatus.INTERNAL_SERVER_ERROR, "사용가능한 프로필 사진이 없습니다."),
+    NO_NICKNAME(HttpStatus.INTERNAL_SERVER_ERROR, "사용가능한 닉네임 형용사가 없습니다."),
+    RANDOM_NUMBER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "랜덤 값을 생성할 수 없습니다."),
+    NO_USER_PLAN(HttpStatus.INTERNAL_SERVER_ERROR, "요금제 등록을 하지 않았습니다."),
+    NO_USER_AND_USER_PLAN(HttpStatus.INTERNAL_SERVER_ERROR, "유저 정보가 존재하지 않거나, 요금제 등록을 하지 않았습니다."),
+    CANT_UPDATE_USER_PLAN(HttpStatus.INTERNAL_SERVER_ERROR, "이미 판매 내역이 있는 요금제로, 요금제를 업데이트할 수 없습니다."),
+    NO_UPDATE_PLAN(HttpStatus.INTERNAL_SERVER_ERROR, "업데이트 가능한 요금제가 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/example/ufo_fi/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/example/ufo_fi/domain/user/exception/UserErrorCode.java
@@ -12,7 +12,7 @@ public enum UserErrorCode implements ErrorCode {
     NO_PHOTO(HttpStatus.INTERNAL_SERVER_ERROR, "사용가능한 프로필 사진이 없습니다."),
     NO_NICKNAME(HttpStatus.INTERNAL_SERVER_ERROR, "사용가능한 닉네임 형용사가 없습니다."),
     RANDOM_NUMBER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "랜덤 값을 생성할 수 없습니다."),
-    NO_USER_PLAN(HttpStatus.INTERNAL_SERVER_ERROR, "요금제 등록을 하지 않았습니다."),
+    NO_USER_PLAN(HttpStatus.INTERNAL_SERVER_ERROR, "회원님의 요금제가 없습니다."),
     NO_USER_AND_USER_PLAN(HttpStatus.INTERNAL_SERVER_ERROR, "유저 정보가 존재하지 않거나, 요금제 등록을 하지 않았습니다."),
     CANT_UPDATE_USER_PLAN(HttpStatus.INTERNAL_SERVER_ERROR, "이미 판매 내역이 있는 요금제로, 요금제를 업데이트할 수 없습니다."),
     NO_UPDATE_PLAN(HttpStatus.INTERNAL_SERVER_ERROR, "업데이트 가능한 요금제가 없습니다."),

--- a/src/main/java/com/example/ufo_fi/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/ufo_fi/domain/user/repository/UserRepository.java
@@ -1,0 +1,20 @@
+package com.example.ufo_fi.domain.user.repository;
+
+import com.example.ufo_fi.domain.user.entity.User;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    @Query("""
+    SELECT u 
+    FROM User u 
+    JOIN FETCH u.userPlan
+    WHERE u.id = :userId
+    """)
+    Optional<User> findUserWithUserPlan(@Param("userId") Long userId);
+
+    List<User> findAllByIdIn(List<Long> followerIds);
+}

--- a/src/main/java/com/example/ufo_fi/domain/user/service/UserService.java
+++ b/src/main/java/com/example/ufo_fi/domain/user/service/UserService.java
@@ -1,0 +1,27 @@
+package com.example.ufo_fi.domain.user.service;
+
+import com.example.ufo_fi.domain.plan.repository.PlanRepository;
+import com.example.ufo_fi.domain.tradepost.repository.TradePostRepository;
+import com.example.ufo_fi.domain.user.dto.response.UserInfoReadRes;
+import com.example.ufo_fi.domain.user.entity.User;
+import com.example.ufo_fi.domain.user.exception.UserErrorCode;
+import com.example.ufo_fi.domain.user.repository.UserRepository;
+import com.example.ufo_fi.global.exception.GlobalException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final PlanRepository planRepository;
+    private final TradePostRepository tradePostRepository;
+
+    public UserInfoReadRes readUser(Long userId) {
+        User user = userRepository.findUserWithUserPlan(userId)
+                .orElseThrow(() -> new GlobalException(UserErrorCode.NO_USER));
+        com.example.ufo_fi.domain.userplan.entity.UserPlan userPlan = user.getUserPlan();
+
+        return UserInfoReadRes.of(user, userPlan);
+    }
+}

--- a/src/main/java/com/example/ufo_fi/domain/user/service/UserService.java
+++ b/src/main/java/com/example/ufo_fi/domain/user/service/UserService.java
@@ -21,7 +21,9 @@ public class UserService {
     public UserInfoReadRes readUser(Long userId) {
         User user = userRepository.findUserWithUserPlan(userId)
                 .orElseThrow(() -> new GlobalException(UserErrorCode.NO_USER));
+
         UserPlan userPlan = user.getUserPlan();
+        if(userPlan == null) throw new GlobalException(UserErrorCode.NO_USER_PLAN);
 
         return UserInfoReadRes.of(user, userPlan);
     }

--- a/src/main/java/com/example/ufo_fi/domain/user/service/UserService.java
+++ b/src/main/java/com/example/ufo_fi/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import com.example.ufo_fi.domain.user.dto.response.UserInfoReadRes;
 import com.example.ufo_fi.domain.user.entity.User;
 import com.example.ufo_fi.domain.user.exception.UserErrorCode;
 import com.example.ufo_fi.domain.user.repository.UserRepository;
+import com.example.ufo_fi.domain.userplan.entity.UserPlan;
 import com.example.ufo_fi.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,7 +21,7 @@ public class UserService {
     public UserInfoReadRes readUser(Long userId) {
         User user = userRepository.findUserWithUserPlan(userId)
                 .orElseThrow(() -> new GlobalException(UserErrorCode.NO_USER));
-        com.example.ufo_fi.domain.userplan.entity.UserPlan userPlan = user.getUserPlan();
+        UserPlan userPlan = user.getUserPlan();
 
         return UserInfoReadRes.of(user, userPlan);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     show-sql: true
 #<============================================================================
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
 #<============================================================================
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #23 
### 🔎 작업 내용

- [x] 유저의 기본 정보를 가져오는 기능

### 📸 스크린샷 (선택)

### 📢 전달사항

- 백엔드 이모저모/모든 쿼리들에 쿼리문 추가했습니다. 테스트 시 사용하시면 될 듯 합니다!

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to retrieve user profile information, including nickname, email, mobile data details, and asset value.
  * Introduced a new response format for user profile data.
  * Implemented user-related error codes for improved error handling.

* **Bug Fixes**
  * Corrected import paths for user repository references in multiple services.

* **Chores**
  * Updated database schema configuration to prevent automatic schema recreation on startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->