### PR TITLE
UF-262 통계 조회 API 추가

### DIFF
--- a/src/main/java/com/example/ufo_fi/domain/statistics/StatisticsController.java
+++ b/src/main/java/com/example/ufo_fi/domain/statistics/StatisticsController.java
@@ -1,0 +1,29 @@
+package com.example.ufo_fi.domain.statistics;
+
+import com.example.ufo_fi.domain.statistics.api.StatisticsApiSpec;
+import com.example.ufo_fi.domain.statistics.dto.response.StatisticsReportsRes;
+import com.example.ufo_fi.domain.statistics.dto.response.StatisticsRes;
+import com.example.ufo_fi.global.response.ResponseBody;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class StatisticsController implements StatisticsApiSpec {
+    private final StatisticsService statisticsService;
+
+    @Override
+    public ResponseEntity<ResponseBody<StatisticsRes>> readStatistics() {
+        return ResponseEntity.ok(
+            ResponseBody.success(
+                statisticsService.readStatistics()));
+    }
+
+    @Override
+    public ResponseEntity<ResponseBody<StatisticsReportsRes>> readStatisticsReports() {
+        return ResponseEntity.ok(
+            ResponseBody.success(
+                statisticsService.readReportsStatistics()));
+    }
+}

--- a/src/main/java/com/example/ufo_fi/domain/statistics/StatisticsService.java
+++ b/src/main/java/com/example/ufo_fi/domain/statistics/StatisticsService.java
@@ -1,0 +1,46 @@
+package com.example.ufo_fi.domain.statistics;
+
+import com.example.ufo_fi.domain.report.repository.ReportRepository;
+import com.example.ufo_fi.domain.statistics.dto.response.StatisticsReportsRes;
+import com.example.ufo_fi.domain.statistics.dto.response.StatisticsRes;
+import com.example.ufo_fi.domain.tradepost.entity.TradePostStatus;
+import com.example.ufo_fi.domain.tradepost.repository.TradePostRepository;
+import com.example.ufo_fi.domain.user.entity.Role;
+import com.example.ufo_fi.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StatisticsService {
+    private final UserRepository userRepository;
+    private final TradePostRepository tradePostRepository;
+
+    public StatisticsRes readStatistics(){
+        long allUsersCount = userRepository.count();
+        long notReportedUsersCount = userRepository.countByRoleNot(Role.ROLE_REPORTED);
+        long allTradePostsCount = tradePostRepository.count();
+        long allReportCount = tradePostRepository.count();
+
+        return StatisticsRes.of(
+            allUsersCount,
+            notReportedUsersCount,
+            allTradePostsCount,
+            allReportCount
+        );
+    }
+
+    public StatisticsReportsRes readReportsStatistics(){
+        long allUsersCount = userRepository.count();
+        long reportedUsersCount = userRepository.countByRole(Role.ROLE_REPORTED);
+        long pendingReportPostCount = tradePostRepository.countPendingReportedPosts();
+        long confirmedReportPostCount = tradePostRepository.countByTradePostStatus(TradePostStatus.REPORTED);
+
+        return StatisticsReportsRes.of(
+            allUsersCount,
+            reportedUsersCount,
+            pendingReportPostCount,
+            confirmedReportPostCount
+        );
+    }
+}

--- a/src/main/java/com/example/ufo_fi/domain/statistics/StatisticsService.java
+++ b/src/main/java/com/example/ufo_fi/domain/statistics/StatisticsService.java
@@ -14,13 +14,14 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class StatisticsService {
     private final UserRepository userRepository;
+    private final ReportRepository reportRepository;
     private final TradePostRepository tradePostRepository;
 
     public StatisticsRes readStatistics(){
         long allUsersCount = userRepository.count();
         long notReportedUsersCount = userRepository.countByRoleNot(Role.ROLE_REPORTED);
         long allTradePostsCount = tradePostRepository.count();
-        long allReportCount = tradePostRepository.count();
+        long allReportCount = reportRepository.count();
 
         return StatisticsRes.of(
             allUsersCount,

--- a/src/main/java/com/example/ufo_fi/domain/statistics/api/StatisticsApiSpec.java
+++ b/src/main/java/com/example/ufo_fi/domain/statistics/api/StatisticsApiSpec.java
@@ -1,0 +1,26 @@
+package com.example.ufo_fi.domain.statistics.api;
+
+import com.example.ufo_fi.domain.plan.dto.response.PlansReadRes;
+import com.example.ufo_fi.domain.statistics.dto.response.StatisticsReportsRes;
+import com.example.ufo_fi.domain.statistics.dto.response.StatisticsRes;
+import com.example.ufo_fi.global.response.ResponseBody;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Statistics API", description = "사용자 통계 API")
+public interface StatisticsApiSpec {
+
+    @Operation(summary = "기본 통계 API", description = "기본 통계를 받아온다.")
+    @ApiResponse(useReturnTypeSchema = true)
+    @GetMapping("/v1/statistics")
+    ResponseEntity<ResponseBody<StatisticsRes>> readStatistics();
+
+    @Operation(summary = "비활성화 통계 API", description = "비활성화 관련 통계를 받아온다.")
+    @ApiResponse(useReturnTypeSchema = true)
+    @GetMapping("/v1/statistics/reports")
+    ResponseEntity<ResponseBody<StatisticsReportsRes>> readStatisticsReports();
+}

--- a/src/main/java/com/example/ufo_fi/domain/statistics/dto/response/StatisticsReportsRes.java
+++ b/src/main/java/com/example/ufo_fi/domain/statistics/dto/response/StatisticsReportsRes.java
@@ -1,0 +1,40 @@
+package com.example.ufo_fi.domain.statistics.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StatisticsReportsRes {
+
+    @Schema(description = "모든 사용자 수 입니다.")
+    private Long allUsersCount;
+
+    @Schema(description = "비활성화된(ROLE_REPORTED) 사용자 수 입니다.")
+    private Long reportedUsersCount;
+
+    @Schema(description = "모든 신고가 3회 이상인 게시물 수 입니다.")
+    private Long pendingReportPostCount;
+
+    @Schema(description = "모든 신고 확정된 게시물 수 입니다.")
+    private Long confirmedReportPostCount;
+
+    public static StatisticsReportsRes of(
+        Long allUsersCount,
+        Long reportedUsersCount,
+        Long pendingReportPostCount,
+        Long confirmedReportPostCount
+    ){
+        return StatisticsReportsRes.builder()
+            .allUsersCount(allUsersCount)
+            .reportedUsersCount(reportedUsersCount)
+            .pendingReportPostCount(pendingReportPostCount)
+            .confirmedReportPostCount(confirmedReportPostCount)
+            .build();
+    }
+}

--- a/src/main/java/com/example/ufo_fi/domain/statistics/dto/response/StatisticsRes.java
+++ b/src/main/java/com/example/ufo_fi/domain/statistics/dto/response/StatisticsRes.java
@@ -1,0 +1,40 @@
+package com.example.ufo_fi.domain.statistics.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StatisticsRes {
+
+    @Schema(description = "모든 사용자의 머릿수")
+    private Long allUsersCount;
+
+    @Schema(description = "신고되지 않은 모든 회원 수")
+    private Long notReportedUsersCount;
+
+    @Schema(description = "모든 거래 게시물 수")
+    private Long allTradePostsCount;
+
+    @Schema(description = "모든 신고 건수")
+    private Long allReportCount;
+
+    public static StatisticsRes of(
+        Long allUsersCount,
+        Long notReportedUsersCount,
+        Long allTradePostsCount,
+        Long allReportCount
+    ){
+        return StatisticsRes.builder()
+            .allUsersCount(allUsersCount)
+            .notReportedUsersCount(notReportedUsersCount)
+            .allTradePostsCount(allTradePostsCount)
+            .allReportCount(allReportCount)
+            .build();
+    }
+}

--- a/src/main/java/com/example/ufo_fi/domain/tradepost/repository/TradePostRepository.java
+++ b/src/main/java/com/example/ufo_fi/domain/tradepost/repository/TradePostRepository.java
@@ -22,4 +22,18 @@ public interface TradePostRepository extends JpaRepository<TradePost, Long>, Tra
     List<TradePost> findAllByUser(User readUser);
 
     List<TradePost> findTradePostByTradePostStatus(TradePostStatus tradePostStatus);
+
+    Long countByTradePostStatus(TradePostStatus tradePostStatus);
+
+    @Query(value = """
+    SELECT COUNT(*) FROM (
+        SELECT tp.id
+        FROM trade_posts tp
+        JOIN reports r ON r.trade_post_id = tp.id
+        WHERE tp.status <> 'REPORTED'
+        GROUP BY tp.id
+        HAVING COUNT(r.id) >= 3
+    ) AS sub
+    """, nativeQuery = true)
+    Long countPendingReportedPosts();
 }

--- a/src/main/java/com/example/ufo_fi/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/ufo_fi/domain/user/repository/UserRepository.java
@@ -15,4 +15,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     User findByKakaoId(String string);
 
     List<User> findAllByRole(Role role);
+
+    long countByRole(Role role);
+
+    long countByRoleNot(Role role);
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #105 

### 🔎 작업 내용

- [x] 사용자 통계를 추가합니다.
- [x] 게시물 통계를 추가합니다.

### 📸 스크린샷 (선택)

### 📢 전달사항

- 추가한 라이브러리, 리뷰 포인트 등

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 전체 사용자, 미신고 사용자, 전체 거래글, 전체 신고 건수 등 통계 정보를 제공하는 새로운 통계 API가 추가되었습니다.
  * 신고된 사용자, 신고 대기 중인 게시글, 신고 확정된 게시글 등 신고 관련 통계 정보를 제공하는 API가 추가되었습니다.

* **버그 수정**
  * 해당 없음.

* **문서화**
  * 통계 API에 대한 Swagger 문서가 추가되어, 응답 필드 설명이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->