### PR TITLE
UF-272 로그아웃 기능 추가

### DIFF
--- a/src/main/java/com/example/ufo_fi/domain/signup/controller/LogoutController.java
+++ b/src/main/java/com/example/ufo_fi/domain/signup/controller/LogoutController.java
@@ -1,0 +1,28 @@
+package com.example.ufo_fi.domain.signup.controller;
+
+import com.example.ufo_fi.domain.signup.controller.api.LogoutApiSpec;
+import com.example.ufo_fi.domain.signup.service.LogoutService;
+import com.example.ufo_fi.global.response.ResponseBody;
+import com.example.ufo_fi.global.security.principal.DefaultUserPrincipal;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class LogoutController implements LogoutApiSpec {
+    private final LogoutService logoutService;
+
+    @Override
+    public ResponseEntity<ResponseBody<Void>> logout(
+        DefaultUserPrincipal defaultUserPrincipal,
+        HttpServletRequest request,
+        HttpServletResponse response
+    ) {
+        logoutService.logout(request, response, defaultUserPrincipal.getId());
+        return ResponseEntity.ok(ResponseBody.noContent());
+    }
+}

--- a/src/main/java/com/example/ufo_fi/domain/signup/controller/api/LogoutApiSpec.java
+++ b/src/main/java/com/example/ufo_fi/domain/signup/controller/api/LogoutApiSpec.java
@@ -1,0 +1,27 @@
+package com.example.ufo_fi.domain.signup.controller.api;
+
+import com.example.ufo_fi.domain.plan.dto.response.PlansReadRes;
+import com.example.ufo_fi.global.response.ResponseBody;
+import com.example.ufo_fi.global.security.principal.DefaultUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Logout API", description = "로그아웃 API")
+public interface LogoutApiSpec {
+
+    @Operation(summary = "로그아웃 API", description = "JWT와 Refresh 토큰을 삭제한다.")
+    @ApiResponse(useReturnTypeSchema = true)
+    @GetMapping("/v1/logout")
+    ResponseEntity<ResponseBody<Void>> logout(
+        @AuthenticationPrincipal DefaultUserPrincipal defaultUserPrincipal,
+        HttpServletRequest httpServletRequest,
+        HttpServletResponse httpServletResponse
+    );
+}

--- a/src/main/java/com/example/ufo_fi/domain/signup/service/LogoutService.java
+++ b/src/main/java/com/example/ufo_fi/domain/signup/service/LogoutService.java
@@ -1,0 +1,24 @@
+package com.example.ufo_fi.domain.signup.service;
+
+import com.example.ufo_fi.global.security.jwt.JwtUtil;
+import com.example.ufo_fi.global.security.refresh.RefreshUtil;
+import com.example.ufo_fi.global.security.refresh.repository.RefreshRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LogoutService {
+    private final JwtUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+
+    public void logout(HttpServletRequest request, HttpServletResponse response, Long userId){
+        // 1. 응답으로 만료시간이 다 된 jwt쿠키를 추가하여, 쿠키를 삭제한다.
+        jwtUtil.deleteJwtCookie(response);
+
+        // 2. Refresh Token 제거
+        refreshRepository.deleteById(userId);
+    }
+}

--- a/src/main/java/com/example/ufo_fi/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/example/ufo_fi/global/security/jwt/JwtUtil.java
@@ -106,6 +106,19 @@ public class JwtUtil {
         validateJwt(jwt, response);                                   // 4
     }
 
+    /**
+     * 1. jwt 토큰을 무효화한다.
+     * 2. 만료시간을 0으로 해서 바로 만료될 수 있도록 설정한다.
+     */
+    public void deleteJwtCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie("Authorization", null);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+    }
+
     // 1.Authorization 헤더에 값이 있는지 검증
     private void validateNotNullAuthorization(Cookie cookie, HttpServletResponse response)
             throws AuthenticationException, IOException {

--- a/src/main/java/com/example/ufo_fi/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/example/ufo_fi/global/security/jwt/JwtUtil.java
@@ -113,7 +113,6 @@ public class JwtUtil {
     public void deleteJwtCookie(HttpServletResponse response) {
         Cookie cookie = new Cookie("Authorization", null);
         cookie.setHttpOnly(true);
-        cookie.setSecure(true);
         cookie.setPath("/");
         cookie.setMaxAge(0);
         response.addCookie(cookie);


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #108 

### 🔎 작업 내용

- [x] JWT 토큰 만료/삭제
- [x] DB의 리프레시 토큰 삭제

### 📸 스크린샷 (선택)

### 📢 전달사항

- 추가한 라이브러리, 리뷰 포인트 등

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 로그아웃 API가 추가되어 사용자가 JWT 및 리프레시 토큰을 삭제하고 로그아웃할 수 있습니다.  
  * 로그아웃 시 인증 쿠키가 만료 처리되며, 저장된 리프레시 토큰도 삭제됩니다.  
  * 로그아웃 요청에 성공하면 200 OK 응답이 반환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->