### PR TITLE
UF-377 tradepost 상세 조회 추가

### DIFF
--- a/src/main/java/com/example/ufo_fi/domain/tradepost/application/TradePostService.java
+++ b/src/main/java/com/example/ufo_fi/domain/tradepost/application/TradePostService.java
@@ -23,6 +23,7 @@ import com.example.ufo_fi.domain.tradepost.presentation.dto.response.TradePostBu
 import com.example.ufo_fi.domain.tradepost.presentation.dto.response.TradePostCommonRes;
 import com.example.ufo_fi.domain.tradepost.presentation.dto.response.TradePostFailPurchaseRes;
 import com.example.ufo_fi.domain.tradepost.presentation.dto.response.TradePostListRes;
+import com.example.ufo_fi.domain.tradepost.presentation.dto.response.TradePostPurchaseDetailRes;
 import com.example.ufo_fi.domain.tradepost.presentation.dto.response.TradePostPurchaseRes;
 import com.example.ufo_fi.domain.user.entity.User;
 import com.example.ufo_fi.domain.user.entity.UserPlan;
@@ -393,4 +394,8 @@ public class TradePostService {
     }
 
 
+    public TradePostPurchaseDetailRes readTradePost(Long postId) {
+        TradePost tradePost = tradePostManager.validateAndFindById(postId);
+        return TradePostPurchaseDetailRes.of(tradePost);
+    }
 }

--- a/src/main/java/com/example/ufo_fi/domain/tradepost/presentation/TradePostController.java
+++ b/src/main/java/com/example/ufo_fi/domain/tradepost/presentation/TradePostController.java
@@ -3,12 +3,14 @@ package com.example.ufo_fi.domain.tradepost.presentation;
 
 import com.example.ufo_fi.domain.tradepost.application.TradePostService;
 import com.example.ufo_fi.domain.tradepost.presentation.api.TradePostApiSpec;
+import com.example.ufo_fi.domain.tradepost.presentation.dto.request.TradePostBulkPurchaseReq;
 import com.example.ufo_fi.domain.tradepost.presentation.dto.request.TradePostCreateReq;
 import com.example.ufo_fi.domain.tradepost.presentation.dto.request.TradePostPurchaseReq;
 import com.example.ufo_fi.domain.tradepost.presentation.dto.request.TradePostQueryReq;
 import com.example.ufo_fi.domain.tradepost.presentation.dto.request.TradePostUpdateReq;
 import com.example.ufo_fi.domain.tradepost.presentation.dto.response.TradePostCommonRes;
 import com.example.ufo_fi.domain.tradepost.presentation.dto.response.TradePostListRes;
+import com.example.ufo_fi.domain.tradepost.presentation.dto.response.TradePostPurchaseDetailRes;
 import com.example.ufo_fi.domain.tradepost.presentation.dto.response.TradePostPurchaseRes;
 import com.example.ufo_fi.global.response.ResponseBody;
 import com.example.ufo_fi.global.security.principal.DefaultUserPrincipal;
@@ -73,5 +75,15 @@ public class TradePostController implements TradePostApiSpec {
         return ResponseEntity.ok(
             ResponseBody.success(
                 tradePostService.purchase(defaultUserPrincipal.getId(), purchaseReq)));
+    }
+
+    @Override
+    public ResponseEntity<ResponseBody<TradePostPurchaseDetailRes>> readTradePost(
+        DefaultUserPrincipal defaultUserPrincipal,
+        Long postId
+    ) {
+        return ResponseEntity.ok(
+            ResponseBody.success(
+                tradePostService.readTradePost(postId)));
     }
 }

--- a/src/main/java/com/example/ufo_fi/domain/tradepost/presentation/api/TradePostApiSpec.java
+++ b/src/main/java/com/example/ufo_fi/domain/tradepost/presentation/api/TradePostApiSpec.java
@@ -7,6 +7,7 @@ import com.example.ufo_fi.domain.tradepost.presentation.dto.request.TradePostQue
 import com.example.ufo_fi.domain.tradepost.presentation.dto.request.TradePostUpdateReq;
 import com.example.ufo_fi.domain.tradepost.presentation.dto.response.TradePostCommonRes;
 import com.example.ufo_fi.domain.tradepost.presentation.dto.response.TradePostListRes;
+import com.example.ufo_fi.domain.tradepost.presentation.dto.response.TradePostPurchaseDetailRes;
 import com.example.ufo_fi.domain.tradepost.presentation.dto.response.TradePostPurchaseRes;
 import com.example.ufo_fi.global.response.ResponseBody;
 import com.example.ufo_fi.global.security.principal.DefaultUserPrincipal;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "TradePost API", description = "거래 게시물 API")
 public interface TradePostApiSpec {
@@ -66,5 +68,13 @@ public interface TradePostApiSpec {
     ResponseEntity<ResponseBody<TradePostPurchaseRes>> purchase(
         @AuthenticationPrincipal DefaultUserPrincipal defaultUserPrincipal,
         @RequestBody TradePostPurchaseReq purchaseReq
+    );
+
+    @Operation(summary = "판매 게시물 상세 조회 API", description = "상세 조회한다.")
+    @ApiResponse(useReturnTypeSchema = true)
+    @GetMapping("/v1/posts/{postId}")
+    ResponseEntity<ResponseBody<TradePostPurchaseDetailRes>> readTradePost(
+        @AuthenticationPrincipal DefaultUserPrincipal defaultUserPrincipal,
+        @RequestParam(name = "postId") Long postId
     );
 }

--- a/src/main/java/com/example/ufo_fi/domain/tradepost/presentation/dto/response/TradePostPurchaseDetailRes.java
+++ b/src/main/java/com/example/ufo_fi/domain/tradepost/presentation/dto/response/TradePostPurchaseDetailRes.java
@@ -1,0 +1,32 @@
+package com.example.ufo_fi.domain.tradepost.presentation.dto.response;
+
+import com.example.ufo_fi.domain.tradepost.domain.TradePost;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TradePostPurchaseDetailRes {
+
+    @Schema(name = "거래 게시물 PK입니다.")
+    private Long postId;
+
+    @Schema(name = "거래 게시물 GB입니다.")
+    private Integer sellMobileDataCapacityGb;
+
+    @Schema(name = "거래 게시물 ZET 가격입니다.")
+    private Integer totalZet;
+
+    public static TradePostPurchaseDetailRes of(final TradePost tradePost){
+        return TradePostPurchaseDetailRes.builder()
+            .postId(tradePost.getId())
+            .sellMobileDataCapacityGb(tradePost.getSellMobileDataCapacityGb())
+            .totalZet(tradePost.getTotalZet())
+            .build();
+    }
+}


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #150 

### 🔎 작업 내용

- [x] trade-post 상세조회 추가

### 📸 스크린샷 (선택)

### 📢 전달사항

- trade-post 상세 조회를 추가했습니다.

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 특정 판매 게시글의 상세 정보를 조회할 수 있는 API 엔드포인트가 추가되었습니다.
  * 판매 게시글의 구매 상세 정보(게시글 ID, 데이터 용량, 총 ZET 가격 등)를 반환하는 응답 형식이 도입되었습니다.
  * API 문서에 해당 엔드포인트가 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->