### PR TITLE
UF-459 알림 로직 수정

### DIFF
--- a/src/main/java/com/example/ufo_fi/v2/interestedpost/application/InterestedPostMapper.java
+++ b/src/main/java/com/example/ufo_fi/v2/interestedpost/application/InterestedPostMapper.java
@@ -1,0 +1,21 @@
+package com.example.ufo_fi.v2.interestedpost.application;
+
+import com.example.ufo_fi.v2.interestedpost.domain.InterestedCarriers;
+import com.example.ufo_fi.v2.interestedpost.domain.InterestedPost;
+import com.example.ufo_fi.v2.interestedpost.presentation.dto.response.InterestedPostRes;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class InterestedPostMapper {
+    public InterestedPostRes toInterestedPostRes(InterestedPost interestedPost, List<InterestedCarriers> interestedCarriers) {
+        return InterestedPostRes.builder()
+                .carriers(interestedCarriers)
+                .interestedMaxCapacity(interestedPost.getInterestedMaxCapacity())
+                .interestedMinCapacity(interestedPost.getInterestedMinCapacity())
+                .interestedMaxPrice(interestedPost.getInterestedMaxPrice())
+                .interestedMinPrice(interestedPost.getInterestedMinPrice())
+                .build();
+    }
+}

--- a/src/main/java/com/example/ufo_fi/v2/interestedpost/application/InterestedPostService.java
+++ b/src/main/java/com/example/ufo_fi/v2/interestedpost/application/InterestedPostService.java
@@ -1,18 +1,23 @@
 package com.example.ufo_fi.v2.interestedpost.application;
 
+import com.example.ufo_fi.v2.interestedpost.domain.InterestedCarriers;
 import com.example.ufo_fi.v2.interestedpost.domain.InterestedPost;
 import com.example.ufo_fi.v2.interestedpost.domain.InterestedPostManager;
 import com.example.ufo_fi.v2.interestedpost.presentation.dto.request.InterestedPostUpdateReq;
+import com.example.ufo_fi.v2.interestedpost.presentation.dto.response.InterestedPostRes;
 import com.example.ufo_fi.v2.user.domain.User;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class InterestedPostService {
 
     private final InterestedPostManager interestedPostManager;
+    private final InterestedPostMapper interestedPostMapper;
     private final EntityManager entityManager;
 
     public void updateInterestedPost(Long userId, InterestedPostUpdateReq request) {
@@ -24,5 +29,15 @@ public class InterestedPostService {
 
         // TODO dto는 어디까지 전달
         interestedPostManager.updateInterestedPost(interestedPost, request, carrierBit);
+    }
+
+    public InterestedPostRes readInterestedPost(Long userId) {
+
+        User userProxy = entityManager.getReference(User.class, userId);
+        InterestedPost interestedPost = interestedPostManager.findByUser(userProxy);
+
+        List<InterestedCarriers> interestedCarriers = interestedPostManager.decodeCarrierBit(interestedPost.getCarrier());
+
+        return interestedPostMapper.toInterestedPostRes(interestedPost, interestedCarriers);
     }
 }

--- a/src/main/java/com/example/ufo_fi/v2/interestedpost/domain/InterestedCarriers.java
+++ b/src/main/java/com/example/ufo_fi/v2/interestedpost/domain/InterestedCarriers.java
@@ -2,6 +2,7 @@ package com.example.ufo_fi.v2.interestedpost.domain;
 
 import com.example.ufo_fi.v2.plan.domain.Carrier;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -26,6 +27,16 @@ public enum InterestedCarriers {
             bitmask |= carrier.getBit();
         }
         return bitmask;
+    }
+
+    public static List<InterestedCarriers> decode(int bitmask) {
+        List<InterestedCarriers> result = new ArrayList<>();
+        for (InterestedCarriers carrier : InterestedCarriers.values()) {
+            if ((bitmask & carrier.getBit()) != 0) {
+                result.add(carrier);
+            }
+        }
+        return result;
     }
 
     public static InterestedCarriers fromCarrier(Carrier carrier) {

--- a/src/main/java/com/example/ufo_fi/v2/interestedpost/domain/InterestedPostManager.java
+++ b/src/main/java/com/example/ufo_fi/v2/interestedpost/domain/InterestedPostManager.java
@@ -35,6 +35,9 @@ public class InterestedPostManager {
     }
 
     public List<InterestedCarriers> decodeCarrierBit(int carrierBit) {
+        if (carrierBit == 0) {
+            return List.of();
+        }
         return InterestedCarriers.decode(carrierBit);
     }
 }

--- a/src/main/java/com/example/ufo_fi/v2/interestedpost/domain/InterestedPostManager.java
+++ b/src/main/java/com/example/ufo_fi/v2/interestedpost/domain/InterestedPostManager.java
@@ -33,4 +33,8 @@ public class InterestedPostManager {
     public List<Long> findMatchedUserIdsWithNotificationEnabled(int zet, int capacity, int carrier, Long sellerId) {
         return interestedPostRepository.findMatchedUserIdsWithNotificationEnabled(zet, capacity, carrier, sellerId);
     }
+
+    public List<InterestedCarriers> decodeCarrierBit(int carrierBit) {
+        return InterestedCarriers.decode(carrierBit);
+    }
 }

--- a/src/main/java/com/example/ufo_fi/v2/interestedpost/presentation/InterestedPostController.java
+++ b/src/main/java/com/example/ufo_fi/v2/interestedpost/presentation/InterestedPostController.java
@@ -1,10 +1,11 @@
 package com.example.ufo_fi.v2.interestedpost.presentation;
 
 import com.example.ufo_fi.global.response.ResponseBody;
+import com.example.ufo_fi.v2.auth.application.principal.DefaultUserPrincipal;
 import com.example.ufo_fi.v2.interestedpost.application.InterestedPostService;
 import com.example.ufo_fi.v2.interestedpost.presentation.api.InterestedPostApiSpec;
 import com.example.ufo_fi.v2.interestedpost.presentation.dto.request.InterestedPostUpdateReq;
-import com.example.ufo_fi.v2.auth.application.principal.DefaultUserPrincipal;
+import com.example.ufo_fi.v2.interestedpost.presentation.dto.response.InterestedPostRes;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,5 +24,12 @@ public class InterestedPostController implements InterestedPostApiSpec {
 
         interestedPostService.updateInterestedPost(defaultUserPrincipal.getId(), request);
         return ResponseEntity.ok(ResponseBody.noContent());
+    }
+
+    @Override
+    public ResponseEntity<ResponseBody<InterestedPostRes>> readInterestedPost(
+            DefaultUserPrincipal defaultUserPrincipal
+    ) {
+        return ResponseEntity.ok(ResponseBody.success(interestedPostService.readInterestedPost(defaultUserPrincipal.getId())));
     }
 }

--- a/src/main/java/com/example/ufo_fi/v2/interestedpost/presentation/api/InterestedPostApiSpec.java
+++ b/src/main/java/com/example/ufo_fi/v2/interestedpost/presentation/api/InterestedPostApiSpec.java
@@ -3,11 +3,13 @@ package com.example.ufo_fi.v2.interestedpost.presentation.api;
 import com.example.ufo_fi.global.response.ResponseBody;
 import com.example.ufo_fi.v2.auth.application.principal.DefaultUserPrincipal;
 import com.example.ufo_fi.v2.interestedpost.presentation.dto.request.InterestedPostUpdateReq;
+import com.example.ufo_fi.v2.interestedpost.presentation.dto.response.InterestedPostRes;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -16,9 +18,17 @@ public interface InterestedPostApiSpec {
 
     @Operation(summary = "관심 상품 등록 조건 설정 API", description = "관심 있는 상품의 알림을 받기 위한 조건을 업데이트합니다.")
     @ApiResponse(useReturnTypeSchema = true)
-    @PatchMapping("/v1/notification-filters/interested-post")
+    @PatchMapping("/notification-filters/interested-post")
     ResponseEntity<ResponseBody<Void>> updateInterestedPost(
             @RequestBody InterestedPostUpdateReq request,
+            @AuthenticationPrincipal DefaultUserPrincipal defaultUserPrincipal
+    );
+
+    // 관심 상품 등록 조건 불러오기
+    @Operation(summary = "관심 상품 등록 조건 조회 API", description = "관심 있는 상품의 조건을 조회 합니다.")
+    @ApiResponse(useReturnTypeSchema = true)
+    @GetMapping("/notification-filters/interested-post")
+    ResponseEntity<ResponseBody<InterestedPostRes>> readInterestedPost(
             @AuthenticationPrincipal DefaultUserPrincipal defaultUserPrincipal
     );
 }

--- a/src/main/java/com/example/ufo_fi/v2/interestedpost/presentation/dto/response/InterestedPostRes.java
+++ b/src/main/java/com/example/ufo_fi/v2/interestedpost/presentation/dto/response/InterestedPostRes.java
@@ -1,0 +1,22 @@
+package com.example.ufo_fi.v2.interestedpost.presentation.dto.response;
+
+import com.example.ufo_fi.v2.interestedpost.domain.InterestedCarriers;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InterestedPostRes {
+
+    private List<InterestedCarriers> carriers;
+    private Integer interestedMaxCapacity;
+    private Integer interestedMinCapacity;
+    private Integer interestedMaxPrice;
+    private Integer interestedMinPrice;
+}

--- a/src/main/java/com/example/ufo_fi/v2/notification/send/application/FcmTokenService.java
+++ b/src/main/java/com/example/ufo_fi/v2/notification/send/application/FcmTokenService.java
@@ -29,53 +29,5 @@ public class FcmTokenService {
         FcmToken fcmToken = fcmManager.saveFcmToken(token, userProxy);
 
         return fcmMapper.toFcmTokenCommonRes(fcmToken);
-        // return new FcmTokenCommonRes(userId);
     }
-// infra 계층으로 분리함
-//    /**
-//     * 멀티 캐스트 (다수 유저용)
-//     */
-//    public void sendMulticastByUserIds(List<Long> userIds, String title, String body, String url) {
-//        List<String> tokens = fcmTokenRepository.findTokensByUserIds(userIds);
-//        if (tokens.isEmpty()) return;
-//
-//        MulticastMessage message = MulticastMessage.builder()
-//                .setNotification(Notification.builder()
-//                        .setTitle(title)
-//                        .setBody(body)
-//                        .build())
-//                .addAllTokens(tokens)
-//                .putData("url", baseUrl + url)
-//                .build();
-//
-//        try {
-//            firebaseMessaging.sendEachForMulticast(message);
-//
-//        } catch (FirebaseMessagingException e) {
-//            throw new GlobalException(NotificationErrorCode.MESSAGE_SEND_FAILED);
-//        }
-//    }
-//
-//    /**
-//     * 유니 캐스트 (단일 유저용)
-//     */
-//    public void sendUnicastByUserId(Long userId, String title, String body, String url) {
-//        Optional<String> tokenOpt = fcmTokenRepository.findByUserId(userId);
-//        tokenOpt.ifPresent(token -> {
-//            Message message = Message.builder()
-//                    .setNotification(Notification.builder()
-//                            .setTitle(title)
-//                            .setBody(body)
-//                            .build())
-//                    .putData("url", baseUrl + url)
-//                    .setToken(token)
-//                    .build();
-//
-//            try {
-//                firebaseMessaging.send(message);
-//            } catch (FirebaseMessagingException e) {
-//                throw new GlobalException(NotificationErrorCode.MESSAGE_SEND_FAILED);
-//            }
-//        });
-//    }
 }

--- a/src/main/java/com/example/ufo_fi/v2/notification/send/application/processor/AccountSuspendNotificationProcessor.java
+++ b/src/main/java/com/example/ufo_fi/v2/notification/send/application/processor/AccountSuspendNotificationProcessor.java
@@ -40,7 +40,8 @@ public class AccountSuspendNotificationProcessor {
 
         List<String> tokens = fcmManager.readFcmTokens(List.of(userId));
         PushMassageCommand pushMassageCommand = PushMassageCommand.from(tokens, message);
-        webPushClient.sendUnicast(pushMassageCommand);
+        // webPushClient.sendUnicast(pushMassageCommand);
+        webPushClient.sendMulticast(pushMassageCommand);
         notificationService.saveNotification(message);
     }
 }

--- a/src/main/java/com/example/ufo_fi/v2/notification/send/application/processor/TradeCompletedNotificationProcessor.java
+++ b/src/main/java/com/example/ufo_fi/v2/notification/send/application/processor/TradeCompletedNotificationProcessor.java
@@ -44,7 +44,8 @@ public class TradeCompletedNotificationProcessor {
         // 3. 전송
         List<String> tokens = fcmManager.readFcmTokens(List.of(userId));
         PushMassageCommand pushMassageCommand = PushMassageCommand.from(tokens, message);
-        webPushClient.sendUnicast(pushMassageCommand);
+        //webPushClient.sendUnicast(pushMassageCommand);
+        webPushClient.sendMulticast(pushMassageCommand);
         notificationService.saveNotification(message);
     }
 }

--- a/src/main/java/com/example/ufo_fi/v2/notification/send/presentation/api/FcmTokenApiSpec.java
+++ b/src/main/java/com/example/ufo_fi/v2/notification/send/presentation/api/FcmTokenApiSpec.java
@@ -17,7 +17,7 @@ public interface FcmTokenApiSpec {
 
     @Operation(summary = "FCM 토큰 저장 API", description = "사용자의 FCM 토큰을 저장한다.")
     @ApiResponse(useReturnTypeSchema = true)
-    @PostMapping("/v1/fcm/token")
+    @PostMapping("/fcm/token")
     ResponseEntity<ResponseBody<FcmTokenCommonRes>> saveToken(
             @RequestBody FcmTokenSaveReq request,
             @AuthenticationPrincipal DefaultUserPrincipal defaultUserPrincipal


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #208 

### 🔎 작업 내용

- [x] FCM 전송방식을 모두 멀티캐스트로 변환했습니다.
- [x] 관심 상품 조건을 조회할 수 있는 엔트포인트 구현했습니다.

### 📸 스크린샷 (선택)

### 📢 전달사항

- 추가한 라이브러리, 리뷰 포인트 등

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 관심 게시글 알림 필터 조건을 조회하는 API가 추가되었습니다.
  * 관심 게시글 정보를 응답하는 새로운 데이터 구조가 도입되었습니다.

* **기능 개선**
  * 관심 게시글 알림 필터 수정 및 조회 API 경로에서 버전 접두어(/v1)가 제거되었습니다.
  * FCM 토큰 저장 API 경로에서 버전 접두어(/v1)가 제거되었습니다.

* **알림 시스템 변경**
  * 일부 푸시 알림 전송 방식이 단일 발송에서 다중 발송으로 변경되었습니다.

* **불필요 코드 정리**
  * FCM 알림 전송 관련 주석 처리된 메서드가 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->