### PR TITLE
UF-462 백오피스 기능 추가

### DIFF
--- a/src/main/java/com/example/ufo_fi/v2/payment/application/PaymentMapper.java
+++ b/src/main/java/com/example/ufo_fi/v2/payment/application/PaymentMapper.java
@@ -1,8 +1,13 @@
 package com.example.ufo_fi.v2.payment.application;
 
 import com.example.ufo_fi.v2.payment.domain.payment.PaymentStatus;
+import com.example.ufo_fi.v2.payment.domain.payment.entity.FailLog;
+import com.example.ufo_fi.v2.payment.domain.payment.entity.Payment;
+import com.example.ufo_fi.v2.payment.presentation.dto.response.FailLogRes;
+import com.example.ufo_fi.v2.payment.presentation.dto.response.PaymentBackOfficesRes;
 import com.example.ufo_fi.v2.payment.presentation.dto.response.ZetRecoveryRes;
 import com.example.ufo_fi.v2.user.domain.User;
+import java.util.List;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -13,5 +18,13 @@ public class PaymentMapper {
                 .zet(user.getZetAsset())
                 .paymentStatus(status)
                 .build();
+    }
+
+    public PaymentBackOfficesRes toPaymentBackOfficesRes(List<Payment> payments) {
+        return PaymentBackOfficesRes.from(payments);
+    }
+
+    public FailLogRes toFailLogRes(FailLog failLog) {
+        return FailLogRes.from(failLog);
     }
 }

--- a/src/main/java/com/example/ufo_fi/v2/payment/domain/backoffice/FailLogManager.java
+++ b/src/main/java/com/example/ufo_fi/v2/payment/domain/backoffice/FailLogManager.java
@@ -1,0 +1,25 @@
+package com.example.ufo_fi.v2.payment.domain.backoffice;
+
+import com.example.ufo_fi.global.exception.GlobalException;
+import com.example.ufo_fi.v2.payment.domain.payment.entity.FailLog;
+import com.example.ufo_fi.v2.payment.exception.PaymentErrorCode;
+import com.example.ufo_fi.v2.payment.persistence.FailLogRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FailLogManager {
+
+    private final FailLogRepository failLogRepository;
+
+    public List<FailLog> findAll() {
+        return failLogRepository.findAll();
+    }
+
+    public FailLog findByOrderId(String orderId) {
+        return failLogRepository.findByOrderId(orderId)
+            .orElseThrow(() -> new GlobalException(PaymentErrorCode.FAIL_LOG_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/ufo_fi/v2/payment/domain/payment/PaymentManager.java
+++ b/src/main/java/com/example/ufo_fi/v2/payment/domain/payment/PaymentManager.java
@@ -10,6 +10,8 @@ import com.example.ufo_fi.v2.user.domain.User;
 import com.example.ufo_fi.v2.user.exception.UserErrorCode;
 import com.example.ufo_fi.v2.user.persistence.UserRepository;
 import jakarta.persistence.EntityManager;
+import java.util.Collection;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -66,5 +68,14 @@ public class PaymentManager {
         if (!((payment.getPrice() / 10) == recoveryZet)) {
             throw new GlobalException(PaymentErrorCode.PAYMENT_AMOUNT_CONFLICT);
         }
+    }
+
+    public List<Payment> findAllByStatusFailAndTimeout() {
+        return paymentRepository.findAllByStatusIn(List.of(PaymentStatus.TIMEOUT, PaymentStatus.FAIL));
+    }
+
+    public Payment findById(Long paymentId) {
+        return paymentRepository.findById(paymentId)
+            .orElseThrow(() -> new GlobalException(PaymentErrorCode.PAYMENT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/example/ufo_fi/v2/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/com/example/ufo_fi/v2/payment/exception/PaymentErrorCode.java
@@ -18,8 +18,8 @@ public enum PaymentErrorCode implements ErrorCode {
     PAYMENT_PRICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "주문 번호의 가격과 요청한 가격이 다릅니다."),
     TOSS_PAYMENT_CONFIRM_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "결제 승인 요청에 실패했습니다."),
     TOSS_PAYMENT_CONFIRM_PARSE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "승인 응답 파싱에 실패했습니다."),
-    TOSS_PAYMENT_CONFIRM_TIME_OUT(HttpStatus.INTERNAL_SERVER_ERROR, "토스와의 통신 시간이 오바되었습니다.")
-    ;
+    TOSS_PAYMENT_CONFIRM_TIME_OUT(HttpStatus.INTERNAL_SERVER_ERROR, "토스와의 통신 시간이 오바되었습니다."),
+    FAIL_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "fail 로그가 없습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/ufo_fi/v2/payment/persistence/FailLogRepository.java
+++ b/src/main/java/com/example/ufo_fi/v2/payment/persistence/FailLogRepository.java
@@ -1,8 +1,10 @@
 package com.example.ufo_fi.v2.payment.persistence;
 
 import com.example.ufo_fi.v2.payment.domain.payment.entity.FailLog;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FailLogRepository extends JpaRepository<FailLog, Long> {
 
+    Optional<FailLog> findByOrderId(String orderId);
 }

--- a/src/main/java/com/example/ufo_fi/v2/payment/persistence/PaymentRepository.java
+++ b/src/main/java/com/example/ufo_fi/v2/payment/persistence/PaymentRepository.java
@@ -1,10 +1,16 @@
 package com.example.ufo_fi.v2.payment.persistence;
 
+import com.example.ufo_fi.v2.payment.domain.payment.PaymentStatus;
 import com.example.ufo_fi.v2.payment.domain.payment.entity.Payment;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     Optional<Payment> findByOrderId(String orderId);
+
+    List<Payment> findAllByStatusIn(Collection<PaymentStatus> paymentStatuses);
 }

--- a/src/main/java/com/example/ufo_fi/v2/payment/presentation/PaymentController.java
+++ b/src/main/java/com/example/ufo_fi/v2/payment/presentation/PaymentController.java
@@ -8,6 +8,8 @@ import com.example.ufo_fi.v2.payment.presentation.dto.request.ConfirmReq;
 import com.example.ufo_fi.v2.payment.presentation.dto.request.PaymentReq;
 import com.example.ufo_fi.v2.payment.presentation.dto.request.ZetRecoveryReq;
 import com.example.ufo_fi.v2.payment.presentation.dto.response.ConfirmRes;
+import com.example.ufo_fi.v2.payment.presentation.dto.response.FailLogRes;
+import com.example.ufo_fi.v2.payment.presentation.dto.response.PaymentBackOfficesRes;
 import com.example.ufo_fi.v2.payment.presentation.dto.response.PaymentRes;
 import com.example.ufo_fi.v2.payment.presentation.dto.response.ZetRecoveryRes;
 import lombok.RequiredArgsConstructor;
@@ -55,4 +57,19 @@ public class PaymentController implements PaymentApiSpec {
                 ResponseBody.success(
                         chargeService.zetRecovery(zetRecoveryReq)));
     }
+
+    @Override
+    public ResponseEntity<ResponseBody<PaymentBackOfficesRes>> readPayments() {
+        return ResponseEntity.ok(
+            ResponseBody.success(
+                chargeService.readPayments()));
+    }
+
+    @Override
+    public ResponseEntity<ResponseBody<FailLogRes>> readFailLog(Long paymentId) {
+        return ResponseEntity.ok(
+            ResponseBody.success(
+                chargeService.readFailLog(paymentId)));
+    }
+
 }

--- a/src/main/java/com/example/ufo_fi/v2/payment/presentation/api/PaymentApiSpec.java
+++ b/src/main/java/com/example/ufo_fi/v2/payment/presentation/api/PaymentApiSpec.java
@@ -2,6 +2,8 @@ package com.example.ufo_fi.v2.payment.presentation.api;
 
 import com.example.ufo_fi.global.response.ResponseBody;
 import com.example.ufo_fi.v2.auth.application.principal.DefaultUserPrincipal;
+import com.example.ufo_fi.v2.payment.presentation.dto.response.FailLogRes;
+import com.example.ufo_fi.v2.payment.presentation.dto.response.PaymentBackOfficesRes;
 import com.example.ufo_fi.v2.payment.presentation.dto.request.ConfirmReq;
 import com.example.ufo_fi.v2.payment.presentation.dto.request.PaymentReq;
 import com.example.ufo_fi.v2.payment.presentation.dto.request.ZetRecoveryReq;
@@ -13,6 +15,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -43,5 +47,17 @@ public interface PaymentApiSpec {
     ResponseEntity<ResponseBody<ZetRecoveryRes>> zetRecovery(
             @RequestBody ZetRecoveryReq zetRecoveryReq,
             @AuthenticationPrincipal DefaultUserPrincipal defaultUserPrincipal
+    );
+
+    @Operation(summary = "관리자 payment 리스트 조회", description = "관리자 권한으로 실패 로그가 있는 payments를 조회한다.")
+    @ApiResponse(useReturnTypeSchema = true)
+    @GetMapping("/admin/payments")
+    ResponseEntity<ResponseBody<PaymentBackOfficesRes>> readPayments();
+
+    @Operation(summary = "관리자 payment 상세 조회", description = "관리자 권한으로 fail_log를 조회한다")
+    @ApiResponse(useReturnTypeSchema = true)
+    @GetMapping("/admin/payments/{paymentId}")
+    ResponseEntity<ResponseBody<FailLogRes>> readFailLog(
+        @PathVariable(name = "paymentId") Long paymentId
     );
 }

--- a/src/main/java/com/example/ufo_fi/v2/payment/presentation/dto/response/FailLogRes.java
+++ b/src/main/java/com/example/ufo_fi/v2/payment/presentation/dto/response/FailLogRes.java
@@ -1,0 +1,36 @@
+package com.example.ufo_fi.v2.payment.presentation.dto.response;
+
+import com.example.ufo_fi.v2.payment.domain.payment.entity.FailLog;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FailLogRes {
+
+    @Schema(description = "실패 주문 키이다.")
+    private String orderId;
+
+    @Schema(description = "클라이언트의 요청이다.")
+    private String confirmReq;
+
+    @Schema(description = "토스 응답이다.")
+    private String confirmResult;
+
+    @Schema(description = "메서드 전이 흐름이다.")
+    private String methodTrace;
+
+    public static FailLogRes from(final FailLog failLog) {
+        return FailLogRes.builder()
+            .orderId(failLog.getOrderId())
+            .confirmReq(failLog.getConfirmReq())
+            .confirmResult(failLog.getConfirmResult())
+            .methodTrace(failLog.getMethodTrace())
+            .build();
+    }
+}

--- a/src/main/java/com/example/ufo_fi/v2/payment/presentation/dto/response/PaymentBackOfficeRes.java
+++ b/src/main/java/com/example/ufo_fi/v2/payment/presentation/dto/response/PaymentBackOfficeRes.java
@@ -1,0 +1,50 @@
+package com.example.ufo_fi.v2.payment.presentation.dto.response;
+
+import com.example.ufo_fi.v2.payment.domain.payment.PaymentStatus;
+import com.example.ufo_fi.v2.payment.domain.payment.entity.Payment;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentBackOfficeRes {
+
+    @Schema(description = "payment PK 입니다.")
+    private Long id;
+
+    @Schema(description = "주문 번호입니다.")
+    private String orderId;
+
+    @Schema(description = "사용자 ID 입니다.")
+    private Long userId;
+
+    @Schema(description = "사용자명입니다.")
+    private String username;
+
+    @Schema(description = "충전 금액입니다.")
+    private Integer price;
+
+    @Schema(description = "상태입니다.")
+    private PaymentStatus paymentStatus;
+
+    @Schema(description = "발행 시각 입니다.")
+    private LocalDateTime requestedAt;
+
+    public static PaymentBackOfficeRes from(final Payment payment) {
+        return PaymentBackOfficeRes.builder()
+            .id(payment.getId())
+            .orderId(payment.getOrderId())
+            .userId(payment.getUser().getId())
+            .username(payment.getUser().getName())
+            .price(payment.getPrice())
+            .paymentStatus(payment.getStatus())
+            .requestedAt(payment.getRequestedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/example/ufo_fi/v2/payment/presentation/dto/response/PaymentBackOfficesRes.java
+++ b/src/main/java/com/example/ufo_fi/v2/payment/presentation/dto/response/PaymentBackOfficesRes.java
@@ -1,0 +1,27 @@
+package com.example.ufo_fi.v2.payment.presentation.dto.response;
+
+import com.example.ufo_fi.v2.payment.domain.payment.entity.Payment;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentBackOfficesRes {
+
+    private List<PaymentBackOfficeRes> paymentBackOfficesRes;
+
+    public static PaymentBackOfficesRes from(final List<Payment> payments) {
+        return PaymentBackOfficesRes.builder()
+            .paymentBackOfficesRes(
+                payments.stream()
+                    .map(PaymentBackOfficeRes::from)
+                    .toList()
+            )
+            .build();
+    }
+}


### PR DESCRIPTION
### #️⃣ 연관된 이슈

> close: #213 

### 🔎 작업 내용

- [x] 백오피스 실패 로그 기능 추가

### 📸 스크린샷 (선택)

### 📢 전달사항

- 백오피스 payment조회, 로그 상세 조회 추가

## ✅ Check List

- [x] 관련 이슈를 등록하고 연결했나요?
- [x] 커밋 메시지 및 PR 제목이 컨벤션을 따랐나요?
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 작성되었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 결제 실패 및 타임아웃 상태의 결제 목록을 조회할 수 있는 관리자용 API가 추가되었습니다.
  * 특정 결제 건의 실패 로그 상세 정보를 조회할 수 있는 관리자용 API가 추가되었습니다.

* **버그 수정**
  * 실패 로그가 존재하지 않을 경우 명확한 오류 메시지가 제공됩니다.

* **문서화**
  * 신규 API 엔드포인트에 대한 OpenAPI 문서가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->